### PR TITLE
SCRUM-1697 restore prod safety-checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,17 +138,20 @@ As the application code is deployed as an AWS lambda function, it can be manuall
 This can be useful to invoke a one-off backup of a specific database/environment before attempting to make manual changes to it,
 or to restore a dump of one environment, to any other environment (and resetting the data in place in the process).
 ```bash
+#To print (readably-formatted) help on all available arguments for the payload:
+aws lambda invoke --function-name agr_db_backups --cli-binary-format raw-in-base64-out  --payload '{"help": "true"}' lambda.output \
+ && jq . lambda.output
 #To invoke an one-off backup, and synchronously wait for its completion.
 # Please change the payload to match the desired application and target environment.
 # Please change the payload to match the desired application and target environment.
 aws --cli-read-timeout 960 lambda invoke --function-name agr_db_backups --cli-binary-format raw-in-base64-out \
  --payload '{"action": "backup", "target_env": "alpha", "identifier": "curation", "region": "us-east-1", "s3_bucket": "agr-db-backups"}' \
- output.file
+ lambda.output
 #To restore the latest production DB backup to the beta environment
 #, and synchronously wait for its completion
 aws --cli-read-timeout 960 lambda invoke --function-name agr_db_backups --cli-binary-format raw-in-base64-out \
  --payload '{"action": "restore", "target_env": "beta", "src_env": "production", "identifier": "curation", "region": "us-east-1", "s3_bucket": "agr-db-backups"}' \
- output.file
+ lambda.output
 ```
 
 Such manual invocations will produce output like the following on STDOUT on success

--- a/app/app.py
+++ b/app/app.py
@@ -20,6 +20,9 @@ def lambda_handler(event, context):
 		's3_bucket' :   'bucket'
 	};
 	args_response = get_args_dict(event, DB_ARG_PARAMS)
+	if 'help' in args_response:
+		logger.info(args_response['help'])
+		return args_response['help']
 	if 'err_msg' in args_response:
 		err_msg = 'Error while retrieving args: '+args_response['err_msg']
 		logger.error(err_msg)
@@ -52,6 +55,28 @@ def get_args_dict(event, arg_set):
 
 	logger = logging.getLogger(__name__)
 
+	help_json = {
+		"description": "This function can backup any AGR database or restore an earlier made"+
+		               " backup to the same or a different environment (e.g. for data roll-down)."+
+		               " Send in a json payload with one or more of the below options as key-value pairs.",
+		"options": {
+			"action":      "Define an action to perform. Value must be either 'backup' or 'restore'.",
+			"db_host":     "Host URL of target DB. Defaults to AWS SSM parameter store value.",
+			"db_name":     "DB name of target DB. Defaults to AWS SSM parameter store value.",
+			"db_password": "DB password for target DB. Defaults to AWS SSM parameter store value.",
+			"db_user":     "DB username for target DB. Defaults to AWS SSM parameter store value.",
+			"help":        "Print this help text (provide any value).",
+			"identifier":  "Application identifier to backup/restore for (for example 'curation').",
+			"region":      "AWS region to retrieve/write backups from/to. Defaults to 'us-east-1'.",
+			"s3_bucket":   "AWS S3 bucket name to retrieve/write backups from/to. Defaults to AWS SSM parameter store value.",
+			"src_env":     "The source environment to find a backup from to restore."+
+			               " Defaults to 'production', only relevant for restore action.",
+			"target_env":  "The target environment to backup/restore from/to. Defaults to 'dev'."
+		}
+	}
+	if 'help' in event:
+		return {'help': help_json}
+
 	#Default values
 	return_args = {
 		'target_env': 'dev',
@@ -59,6 +84,7 @@ def get_args_dict(event, arg_set):
 		'region': 'us-east-1'
 	}
 
+	#Input argument validation
 	if 'action' in event:
 		if event['action'] not in ('backup', 'restore'):
 			error_message = "Argument action can only have value 'backup' or 'restore'"

--- a/app/app.py
+++ b/app/app.py
@@ -60,18 +60,20 @@ def get_args_dict(event, arg_set):
 		               " backup to the same or a different environment (e.g. for data roll-down)."+
 		               " Send in a json payload with one or more of the below options as key-value pairs.",
 		"options": {
-			"action":      "Define an action to perform. Value must be either 'backup' or 'restore'.",
-			"db_host":     "Host URL of target DB. Defaults to AWS SSM parameter store value.",
-			"db_name":     "DB name of target DB. Defaults to AWS SSM parameter store value.",
-			"db_password": "DB password for target DB. Defaults to AWS SSM parameter store value.",
-			"db_user":     "DB username for target DB. Defaults to AWS SSM parameter store value.",
-			"help":        "Print this help text (provide any value).",
-			"identifier":  "Application identifier to backup/restore for (for example 'curation').",
-			"region":      "AWS region to retrieve/write backups from/to. Defaults to 'us-east-1'.",
-			"s3_bucket":   "AWS S3 bucket name to retrieve/write backups from/to. Defaults to AWS SSM parameter store value.",
-			"src_env":     "The source environment to find a backup from to restore."+
-			               " Defaults to 'production', only relevant for restore action.",
-			"target_env":  "The target environment to backup/restore from/to. Defaults to 'dev'."
+			"action":       "Define an action to perform. Value must be either 'backup' or 'restore'.",
+			"db_host":      "Host URL of target DB. Defaults to AWS SSM parameter store value.",
+			"db_name":      "DB name of target DB. Defaults to AWS SSM parameter store value.",
+			"db_password":  "DB password for target DB. Defaults to AWS SSM parameter store value.",
+			"db_user":      "DB username for target DB. Defaults to AWS SSM parameter store value.",
+			"help":         "Print this help text (provide any value).",
+			"identifier":   "Application identifier to backup/restore for (for example 'curation').",
+			"prod_restore": "Extra flag to prevent accidental restores to 'production' environments."+
+			                " Define this argument as 'true' to confirm intend to do a production environment restore.",
+			"region":       "AWS region to retrieve/write backups from/to. Defaults to 'us-east-1'.",
+			"s3_bucket":    "AWS S3 bucket name to retrieve/write backups from/to. Defaults to AWS SSM parameter store value.",
+			"src_env":      "The source environment to find a backup from to restore."+
+			                " Defaults to 'production', only relevant for restore action.",
+			"target_env":   "The target environment to backup/restore from/to. Defaults to 'dev'."
 		}
 	}
 	if 'help' in event:
@@ -112,6 +114,12 @@ def get_args_dict(event, arg_set):
 		error_message = "Action 'restore' is not allowed to target env {target} from source env {source}."\
 		                .format(target=return_args['target_env'],source=return_args['src_env'])
 		return {'err_msg': error_message}
+
+	# Prevent accidental production environment restore
+	if return_args['action'] == 'restore' and return_args['target_env'] == 'production':
+		if 'prod_restore' not in event or event['prod_restore'] != 'true':
+			error_message = "Action 'restore' to target env production requested, but prod_restore is not defined as 'true'."
+			return {'err_msg': error_message}
 
 	if 'region' in event:
 		return_args['region'] = event['region']


### PR DESCRIPTION
* Added additional argument to confirm intent to restore to production
* Block restores of lower-consistency environment's data to higher consistency environments (data must always go prod > beta > alpha > dev)
* Added option for function payload help printing